### PR TITLE
fixed home page's join hackathon banner

### DIFF
--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -4,10 +4,11 @@ import { faqs } from "../../../data/faqData";
 import Venue from "@/components/Venue";
 import VenueContact from "@/components/VenueContact";
 import Background from "@/components/Background";
+import LightBoxOthers from "@/components/LightBoxOthers";
 
 const Page = () => {
   return (
-    <div className="relative overflow-x-clip">
+    <div className="relative w-[100%] overflow-x-clip">
       {/*<XComponent />*/}
       <Background />
 
@@ -24,7 +25,8 @@ const Page = () => {
           </div>
           {/* Transport cards + Map  */}
           <Venue />
-
+          {/* Lightbox */}
+          <LightBoxOthers name="contact" id={0} />
           {/* FAQ Section */}
 
           <FAQClient faqs={faqs} />

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -100,7 +100,7 @@ const HeroSection = () => {
         <HackathonStats />
 
         {/* CTA Buttons */}
-        <div className="mt-12 mb-15 hidden flex-col gap-4 sm:flex-row lg:mt-15 lg:flex">
+        <div className="mb:mt-12 -mt-7 mb-7 flex-col gap-4 sm:flex-row md:mb-15 lg:mt-15 lg:flex">
           <JoinHackathonBanner />
         </div>
         <div className="w-full">

--- a/frontend/src/components/JoinHackathon.tsx
+++ b/frontend/src/components/JoinHackathon.tsx
@@ -3,19 +3,20 @@ import Image from "next/image";
 
 const JoinHackathonBanner = () => {
   return (
-    <div className="relative flex h-[180px] w-full max-w-[950px] items-center justify-between overflow-hidden rounded-full bg-[#0a0f2b] px-18 py-12 md:py-8">
+    <div className="relative flex h-[clamp(6rem,12vw,10rem)] w-[clamp(18rem,90vw,60rem)] flex-col-reverse items-center justify-between gap-6 overflow-hidden rounded-full bg-[#0a0f2b] px-4 py-6 sm:flex-row sm:px-8 md:w-[clamp(18rem,70vw,60rem)] md:px-12 lg:px-16">
       {/* Left Content */}
-      <div className="text-offwhite z-10 flex flex-col items-start gap-3">
-        <h2 className="font-kinetikaUltra text-left text-xl leading-tight font-extrabold text-nowrap sm:text-lg md:text-2xl lg:text-3xl">
+      <div className="text-offwhite z-10 flex flex-col items-start">
+        <h2 className="font-kinetikaUltra absolute top-[clamp(1.4rem,2.8vw,2.8rem)] left-[clamp(1.3rem,5vw,5rem)] text-left text-xl leading-tight font-extrabold text-nowrap sm:text-lg md:text-2xl lg:text-[2rem]">
           JOIN THE HACKATHON!
         </h2>
-        <button className="xs:px-5 xs:py-3 xs:text-base text-offwhite min-h-[34px] w-full max-w-xs transform rounded-full border-2 border-white bg-transparent px-2 py-1.5 text-sm font-extrabold tracking-wide whitespace-nowrap shadow-lg transition-all duration-300 hover:scale-105 hover:border-white/30 hover:bg-white hover:text-black hover:shadow-xl focus:scale-105 focus:ring-4 focus:ring-white/50 focus:outline-none active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100 sm:min-h-[48px] sm:px-6 sm:py-3 sm:text-lg md:min-h-[52px] md:w-3/5 md:px-4 md:py-1.5 md:text-base lg:min-h-[36px]">
+        {/*<button */}
+        <button className="text-offwhite absolute bottom-[clamp(1.4rem,3.2vw,3.2rem)] left-[clamp(1.3rem,5vw,5rem)] transform rounded-full border-[clamp(0.05rem,0.13vw,0.13rem)] border-white bg-transparent px-[clamp(0.7rem,2vw,2rem)] py-[clamp(0.3rem,0.35vw,0.35rem)] text-sm text-[clamp(0.5rem,0.9vw,0.9rem)] font-extrabold tracking-wide whitespace-nowrap shadow-lg transition-all duration-300 hover:scale-105 hover:border-white/30 hover:bg-white hover:text-black hover:shadow-xl focus:scale-105 focus:ring-4 focus:ring-white/50 focus:outline-none active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100">
           REGISTER NOW
         </button>
       </div>
 
       {/* Right Image */}
-      <div className="relative mb-40 h-[300px] w-[100px] sm:h-[400px] sm:w-[400px] md:h-[500px] md:w-[800px]">
+      <div className="absolute -bottom-[clamp(8rem,12vw,12rem)] left-[clamp(10rem,30.5vw,30.5rem)] w-[clamp(13rem,25vw,25rem]">
         <Image
           src="/HeroSection/ChipsSpline3.svg"
           alt="Glowing Shape"

--- a/frontend/src/components/LightBoxOthers.tsx
+++ b/frontend/src/components/LightBoxOthers.tsx
@@ -106,6 +106,20 @@ const LightBoxOthers = (props: { name: string; id: number }) => {
         </>
       );
     }
+  } else if (props.name.toLowerCase() === "contact") {
+    // Contact :
+    return (
+      <>
+        {/*lightbox mobile right*/}
+        <div className="absolute top-[110rem] -right-60 -z-10 h-[20rem] w-300 opacity-100 md:hidden">
+          <LightBlock position="right" />
+        </div>
+        {/*lightbox mobile left*/}
+        <div className="absolute top-[60rem] -left-180 -z-10 h-[20rem] w-400 opacity-100 md:hidden">
+          <LightBlock position="left" />
+        </div>
+      </>
+    );
   }
 };
 


### PR DESCRIPTION
**Title :** added lightboxes in contact pages' mobile view, cause I saw them in the Figma design

**Description :**
noticed that the join hackathon banner in the homepage was not showing in mobile view, so made it responsive by editing css in Hero.tsx and JoinHackathon.tsx.
used **clamp(min (rem), preffered (vw), max( rem))** to make the elements more responsive.

**Files Changed :** 
- LightBoxOthers.jsx
- contact/page.tsx
- Hero.jsx
- JoinHackathon.tsx

**Checklist :**
- [ ✅ ] Code/content reviewed
- [ ✅ ] Follows brand/style guidelines
- [ ✅ ] No unused files or test data
- [ ✅ ] Ready for review

