### PR TITLE
fixed css rendering issue

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -49,7 +49,7 @@ const Navbar: React.FC = () => {
       alt: "Gallery",
       label: "Gallery",
       path: "/gallery",
-      darkIcon: "gallery.svg",
+      darkIcon: "galleryDark.svg",
     },
     {
       icon: "contact.svg",
@@ -118,7 +118,7 @@ const Navbar: React.FC = () => {
 
       {/* Mobile Menu Overlay */}
       <div
-        className={`fixed inset-0 z-40 transition-all duration-500 ease-in-out md:hidden ${
+        className={`fixed inset-0 z-40 backdrop-blur-lg transition-opacity duration-500 ease-in-out md:hidden ${
           isMenuOpen
             ? "pointer-events-auto opacity-100"
             : "pointer-events-none opacity-0"
@@ -126,7 +126,7 @@ const Navbar: React.FC = () => {
       >
         {/* Backdrop - Transparent */}
         <div
-          className="backdrop-transparent absolute inset-0 bg-black/30"
+          className="absolute inset-0 bg-black/30"
           onClick={() => setIsMenuOpen(false)}
         />
 
@@ -136,7 +136,7 @@ const Navbar: React.FC = () => {
             isMenuOpen ? "translate-x-0" : "translate-x-full"
           }`}
         >
-          <div className="h-full rounded-l-3xl border-t border-b border-l border-white/20 bg-black/20 p-6 shadow-2xl backdrop-blur-md">
+          <div className="h-full rounded-l-3xl border-t border-b border-l border-white/20 bg-black/20 p-6 shadow-2xl">
             {/* Close Button */}
             {/* <div className="flex justify-end mb-8">
               <button 
@@ -149,7 +149,7 @@ const Navbar: React.FC = () => {
             </div> */}
 
             {/* Nav Items */}
-            <div className="mt-8 rounded-4xl bg-white/15 p-4 backdrop-blur-sm">
+            <div className="mt-8 rounded-4xl bg-white/15 p-4">
               <nav className="space-y-2">
                 {sidebarItems.map((item) => {
                   const isActive = pathname === item.path;


### PR DESCRIPTION
###  Fixed sidebar CSS rendering issue

###  Description
- In this pull request, I fixed the backdrop blur slow rendering issue in the sidebar (mobile view).

- This was needed to be done because whenever the side bar was being opened the background would be showing after the entire transform animation
- Why? This is because the browser was priortising the transform animation over the backdrop-blur effect. So only after the entire transformation the backdrop-blur effect would be implemented.
- So I just removed the backdrop blur effect from being after the transform effect to being in the same class as the transformation animation.
- This fixed the background slow render issue. But it also added a blur in the back of the sidebar. It looks aesthetic to me but I would like to put it to review.

before :

<img width="350" height="610" alt="Screenshot 2025-09-01 at 16 19 38" src="https://github.com/user-attachments/assets/65c5863f-3386-412b-a01e-79f043c41046" />

after :

<img width="350" height="610" alt="Screenshot 2025-09-01 at 16 19 13" src="https://github.com/user-attachments/assets/15d77a08-ad2c-4479-beff-be04df906c6d" />


###  Files Changed
- Navbar.tsx (mobile view) was only changed here.

###  Checklist

- [x] Code/content reviewed
- [x] Follows brand/style guidelines
- [x] No unused files or test data
- [x] Ready for review

